### PR TITLE
increment podfile with release, for real

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -220,7 +220,7 @@ PODS:
   - React-jsinspector (0.69.3)
   - React-logger (0.69.3):
     - glog
-  - react-native-snapyr-rn-sdk (1.0.0-beta.3):
+  - react-native-snapyr-rn-sdk (1.0.0-beta.4):
     - React-Core
     - Snapyr
   - React-perflogger (0.69.3)
@@ -427,7 +427,7 @@ SPEC CHECKSUMS:
   React-jsiexecutor: 1842ca163b160aeb224d2c65b2a60c393b273c67
   React-jsinspector: bb2605f98aada5d81f3494690da3ef3b4ff3b716
   React-logger: 23a50ef4c18bf9adbb51e2c979318e6b3a2e44a1
-  react-native-snapyr-rn-sdk: 0026c4bff7d9f5208af916e847e7a6c7e77acbb5
+  react-native-snapyr-rn-sdk: 544cda6e9794e7d00c4689209155c4846ad9fecf
   React-perflogger: 39d2ba8cbcac54d1bb1d9a980dab348e96aef467
   React-RCTActionSheet: b1ad907a2c8f8e4d037148ca507b7f2d6ab1c66d
   React-RCTAnimation: 914a9ba46fb6e7376f7709c7ce825d53b47ca2ee

--- a/package.json
+++ b/package.json
@@ -111,8 +111,7 @@
         "yarn typescript:check"
       ],
       "after:bump": [
-        "yarn",
-        "git add example/ios/Podfile.lock",
+        "yarn pods",
         "yarn prepare"
       ],
       "after:release": "echo Successfully released ${name} v${version} to ${repo.repository}."


### PR DESCRIPTION
Apparently release-it doesn't play nicely with the boostrap script, so we can just call `yarn pods` directly. 