### PR TITLE
Add notification tracking calls - iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ import { configure, identify, track } from '@snapyr/react-native-sdk';
 await configure('writeKey');
 await identify('userId@here.com', { traits: 'optional' });
 await track('someEvent', { some: 'properties', for: 'example' });
+
+// after receiving a push notification payload, track received metric to Snapyr
+const snapyrData = notification.data?.snapyr;
+await pushNotificationReceived(snapyrData);
+
+// after receiving a push interaction callback, track tapped metric to Snapyr
+const snapyrData = notification.data?.snapyr;
+await pushNotificationTapped(snapyrData);
 ```
 
 ## Development

--- a/ios/SnapyrRnSdk.m
+++ b/ios/SnapyrRnSdk.m
@@ -13,20 +13,23 @@ RCT_REMAP_METHOD(configure,
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 {
-  SnapyrSDKConfiguration *configuration = [SnapyrSDKConfiguration configurationWithWriteKey:key];
-  if ([_options objectForKey:@"trackApplicationLifecycleEvents"]) {
-    configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically
-  }
-  if ([_options objectForKey:@"recordScreenViews"]) {
-    configuration.recordScreenViews = YES; // Enable this to record screen views automatically
-  }
-  if ([_options objectForKey:@"enableDevMode"]) {
-    configuration.enableDevEnvironment = YES; // Test against a Snapyr dev environment *internal only*
-  }
-
-  [SnapyrSDK setupWithConfiguration:configuration];
-
-  resolve(key);
+    SnapyrSDKConfiguration *configuration = [SnapyrSDKConfiguration configurationWithWriteKey:key];
+    if ([_options objectForKey:@"trackApplicationLifecycleEvents"]) {
+        configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically
+    }
+    if ([_options objectForKey:@"recordScreenViews"]) {
+        configuration.recordScreenViews = YES; // Enable this to record screen views automatically
+    }
+    if ([_options objectForKey:@"enableDevMode"]) {
+        configuration.enableDevEnvironment = YES; // Test against a Snapyr dev environment *internal only*
+    }
+    
+    // makes every event flush to network immediately
+    configuration.flushAt = 1;
+    
+    [SnapyrSDK setupWithConfiguration:configuration];
+    
+    resolve(key);
 }
 
 RCT_EXPORT_METHOD(identify:(NSString*)_userId traits:(NSDictionary*)_traits)
@@ -49,6 +52,18 @@ RCT_EXPORT_METHOD(setPushNotificationToken:(NSString*)_token)
 {
     NSLog(@"%@ tokenNSLOG", _token);
     [[SnapyrSDK sharedSDK] setPushNotificationToken: _token];
+}
+
+RCT_EXPORT_METHOD(pushNotificationReceived:(NSDictionary*)_snapyrData)
+{
+    [[SnapyrSDK sharedSDK] pushNotificationReceived:[_snapyrData copy]];
+}
+
+RCT_EXPORT_METHOD(pushNotificationTapped:(NSDictionary*)_snapyrData actionId:(NSString* _Nullable)actionId)
+{
+    // TODO: add back actionId after releasing iOS SDK update w/ Action Buttons support
+    //    [[SnapyrSDK sharedSDK] pushNotificationTapped:[_snapyrData copy] actionId:actionId];
+    [[SnapyrSDK sharedSDK] pushNotificationTapped:[_snapyrData copy]];
 }
 
 @end

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -32,3 +32,11 @@ export function track(eventName: string, properties?: any): Promise<string> {
 export function setPushNotificationToken(token: string) {
   return SnapyrRnSdk.setPushNotificationToken(token);
 }
+
+export function pushNotificationReceived(snapyrData: any): Promise<void> {
+  return SnapyrRnSdk.pushNotificationReceived(snapyrData);
+}
+
+export function pushNotificationTapped(snapyrData: any, actionId?: string): Promise<void> {
+  return SnapyrRnSdk.pushNotificationTapped(snapyrData, actionId);
+}


### PR DESCRIPTION
Add `pushNotificationReceived` and `pushNotificationTapped` - these map to the standard native methods in the iOS SDK and allow for tracking of notification delivery/interaction metrics.