### PR TITLE
iOS in-app support and native push events

### DIFF
--- a/ios/SnapyrRnSdk.h
+++ b/ios/SnapyrRnSdk.h
@@ -1,9 +1,11 @@
 #import <React/RCTBridgeModule.h>
 #import <React/RCTEventEmitter.h>
+#import <UserNotifications/UserNotifications.h>
 
 @interface SnapyrRnSdk : RCTEventEmitter <RCTBridgeModule>
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
++ (void)didReceiveNotificationResponse:(UNNotificationResponse *)response;
 
 @end

--- a/ios/SnapyrRnSdk.h
+++ b/ios/SnapyrRnSdk.h
@@ -1,5 +1,7 @@
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
+@interface SnapyrRnSdk : RCTEventEmitter <RCTBridgeModule>
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;

--- a/ios/SnapyrRnSdk.h
+++ b/ios/SnapyrRnSdk.h
@@ -1,5 +1,7 @@
 #import <React/RCTBridgeModule.h>
 
-@interface SnapyrRnSdk : NSObject <RCTBridgeModule>
+
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
++ (void)didReceiveRemoteNotification:(NSDictionary *)notification;
 
 @end

--- a/ios/SnapyrRnSdk.m
+++ b/ios/SnapyrRnSdk.m
@@ -72,4 +72,97 @@ RCT_EXPORT_METHOD(reset)
     // Do nothing, for now... stub method to maintain compat w/ Android
 }
 
+
+/**
+ Native iOS -> React Native events (trigger RN callbacks from native)
+ */
+
+- (NSArray<NSString *> *)supportedEvents
+{
+  return @[
+      @"snapyrDidRegister",
+      @"snapyrDidReceiveNotification",
+  ];
+}
+
+// https://reactnative.dev/docs/native-modules-ios#sending-events-to-javascript
+// Will be called when this module's first listener is added.
+// NB (PS): React Native auto initializes an instance of this class at startup and `startObserving` is
+// called to register any listeners we need.
+//
+// We provide class methods (kinda like static methods) for end user code to call so they don't need
+// to manage lifecycle. Those class methods use NSNotificationCenter to pass the data along through
+// events; we listen to those events here in the actual instance, where we can then pass data back
+// into React Native.
+-(void)startObserving {
+    NSLog(@"XXX: startObserving");
+    // Set up any upstream listeners or background tasks as necessary
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(handleSnapyrDidRegister:)
+     name:@"snapyrDidRegister"
+     object:nil];
+    
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(handleSnapyrDidReceiveNotification:)
+     name:@"snapyrDidReceiveNotification"
+     object:nil];
+}
+
+// Will be called when this module's last listener is removed, or on dealloc.
+-(void)stopObserving {
+    NSLog(@"XXX: stopObserving");
+    // Remove upstream listeners, stop unnecessary background tasks
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+
+- (void)handleSnapyrDidRegister:(NSNotification *)notification
+{
+    NSLog(@"XXX: handleSnapyrDidRegister: %@", notification.userInfo);
+    NSString *token = notification.userInfo[@"token"];
+    [self sendEventWithName:@"snapyrDidRegister" body:token];
+}
+
+- (void)handleSnapyrDidReceiveNotification:(NSNotification *)notification
+{
+    NSLog(@"XXX: handleSnapyrDidReceiveNotification: %@", notification.userInfo);
+    NSDictionary *notif = notification.userInfo[@"notification"];
+    [self sendEventWithName:@"snapyrDidReceiveNotification" body:notif];
+}
+
++ (void)didReceiveRemoteNotification:(NSDictionary *)notification
+{
+    NSLog(@"XXX: didReceiveRemoteNotification: %@", notification);
+    [[NSNotificationCenter defaultCenter]
+     postNotificationName:@"snapyrDidReceiveNotification"
+     object:self
+     userInfo:@{@"notification": notification}];
+}
+
+// Class method the consumer can call when application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
+// has been triggered on the AppDelegate.
+// Decodes token and passes it through NSNotificationCenter so it can be processed by the instance method
+// `handleSnapyrDidRegister`
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+{
+    NSLog(@"XXX: didRegisterForRemoteNotificationsWithDeviceToken: %@", deviceToken);
+    NSUInteger dataLength = deviceToken.length;
+    if (dataLength == 0) {
+        return;
+    }
+    
+    const unsigned char *dataBuffer = (const unsigned char *)deviceToken.bytes;
+    NSMutableString *hexString = [NSMutableString stringWithCapacity:(dataLength * 2)];
+    for (int i = 0; i < dataLength; ++i) {
+        [hexString appendFormat:@"%02x", dataBuffer[i]];
+    }
+    
+    [[NSNotificationCenter defaultCenter]
+     postNotificationName:@"snapyrDidRegister"
+     object:self
+     userInfo:@{@"token" : [hexString copy]}];
+}
+
 @end

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,6 +3,7 @@ import { EmitterSubscription, NativeEventEmitter, NativeModules, Platform } from
 const SNAPYR_LISTENER_REGISTER = 'snapyrDidRegister';
 const SNAPYR_LISTENER_NOTIFICATION = 'snapyrDidReceiveNotification';
 const SNAPYR_LISTENER_NOTIFICATION_RESPONSE = 'snapyrDidReceiveNotificationResponse';
+const SNAPYR_LISTENER_INAPP_MESSAGE = 'snapyrInAppMessage';
 
 const LINKING_ERROR =
   `The package 'snapyr-react-native-sdk' doesn't seem to be linked. Make sure: \n\n` +
@@ -21,12 +22,34 @@ const SnapyrRnSdk = NativeModules.SnapyrRnSdk
       }
     );
 
+export enum SnapyrEnvironment {
+  SnapyrEnvironmentDefault,
+  SnapyrEnvironmentStage,
+  SnapyrEnvironmentDev,
+};
+
+export type SnapyrConfigOptions = {
+  trackApplicationLifecycleEvents: boolean,
+  recordScreenViews: boolean,
+  snapyrEnvironment: SnapyrEnvironment,
+};
+
+export type SnapyrInAppMessage = { 
+  timestamp: string,
+  actionType: 'custom' | 'overlay',
+  userId: string,
+  actionToken: string,
+  content: {
+    payloadType: 'json' | 'html',
+    payload: string, 
+  } 
+};
+
 export const SnapyrEmitter = new NativeEventEmitter(SnapyrRnSdk);
 // Client code can register listeners (callbacks) on SDK events; use a map to limit to 1 listener per event type
 const _eventListeners = new Map<string, EmitterSubscription>();
 
 export function onSnapyrDidRegister(callback: (token: string) => void): void {
-  console.log("JSSDK: onSnapyrDidRegister registration");
   const listener = SnapyrEmitter.addListener(
     SNAPYR_LISTENER_REGISTER,
     (token) => callback(token),
@@ -37,17 +60,27 @@ export function onSnapyrDidRegister(callback: (token: string) => void): void {
 }
 
 export function onSnapyrDidReceiveNotification(callback: (notification: any) => void): void {
-  console.log("JSSDK: onSnapyrDidReceive registration");
   const listener = SnapyrEmitter.addListener(
     SNAPYR_LISTENER_NOTIFICATION,
     (notification) => {
-      console.log("JSSDK: NOTIFICATION", notification);
       callback(notification);
     },
   );
   // Remove/unsubscribe previous listener, if any
   _eventListeners.get(SNAPYR_LISTENER_NOTIFICATION)?.remove();
   _eventListeners.set(SNAPYR_LISTENER_NOTIFICATION, listener);
+}
+
+export function onSnapyrInAppMessage(callback: (message: SnapyrInAppMessage) => void): void {
+  const listener = SnapyrEmitter.addListener(
+    SNAPYR_LISTENER_INAPP_MESSAGE,
+    (message: SnapyrInAppMessage) => {
+      callback(message);
+    },
+  );
+  // Remove/unsubscribe previous listener, if any
+  _eventListeners.get(SNAPYR_LISTENER_INAPP_MESSAGE)?.remove();
+  _eventListeners.set(SNAPYR_LISTENER_INAPP_MESSAGE, listener);
 }
 
 export function onSnapyrDidReceiveNotificationResponse(callback: ({actionIdentifier, userInfo}: {actionIdentifier: string, userInfo: Record<string, any>}) => void): void {
@@ -64,8 +97,7 @@ export function onSnapyrDidReceiveNotificationResponse(callback: ({actionIdentif
   _eventListeners.set(SNAPYR_LISTENER_NOTIFICATION_RESPONSE, listener);
 }
 
-export function configure(key: string, options?: any): Promise<string> {
-  console.log("XXX JSSDK: config start:", SnapyrEmitter);
+export function configure(key: string, options?: Partial<SnapyrConfigOptions>): Promise<string> {
   // SnapyrRnSdk.addListener('snapyrTestListener');
   // console.log("XXX JSSDK: config after addListener:", SnapyrEmitter);
   // SnapyrEmitter = new NativeEventEmitter(SnapyrRnSdk);
@@ -75,7 +107,7 @@ export function configure(key: string, options?: any): Promise<string> {
   // SnapyrEmitter.addListener('snapyrTestListener', (x) => {
   //   // console.log("XXX JSSDK TEST LISTENER!!!!!!!!!!!", x);
   // });
-  SnapyrEmitter.addListener('snapyrTestThing', (x) => {
+  SnapyrEmitter.addListener('snapyrTest', (x) => {
     console.log("XXX TEST THING::::::", x);
   });
   return ret;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,11 +84,9 @@ export function onSnapyrInAppMessage(callback: (message: SnapyrInAppMessage) => 
 }
 
 export function onSnapyrDidReceiveNotificationResponse(callback: ({actionIdentifier, userInfo}: {actionIdentifier: string, userInfo: Record<string, any>}) => void): void {
-  console.log("JSSDK: onSnapyrDidReceiveResponse registration");
   const listener = SnapyrEmitter.addListener(
     SNAPYR_LISTENER_NOTIFICATION_RESPONSE,
     (responseData) => {
-      console.log("JSSDK: RESPONSE", responseData);
       callback(responseData);
     },
   );
@@ -98,19 +96,7 @@ export function onSnapyrDidReceiveNotificationResponse(callback: ({actionIdentif
 }
 
 export function configure(key: string, options?: Partial<SnapyrConfigOptions>): Promise<string> {
-  // SnapyrRnSdk.addListener('snapyrTestListener');
-  // console.log("XXX JSSDK: config after addListener:", SnapyrEmitter);
-  // SnapyrEmitter = new NativeEventEmitter(SnapyrRnSdk);
-  
-  // console.log("XXX JSSDK: config after NativeEventEmitter:", SnapyrEmitter);
-  const ret = SnapyrRnSdk.configure(key, options);
-  // SnapyrEmitter.addListener('snapyrTestListener', (x) => {
-  //   // console.log("XXX JSSDK TEST LISTENER!!!!!!!!!!!", x);
-  // });
-  SnapyrEmitter.addListener('snapyrTest', (x) => {
-    console.log("XXX TEST THING::::::", x);
-  });
-  return ret;
+  return SnapyrRnSdk.configure(key, options);
 }
 
 export function identify(id: string, traits?: any): Promise<string> {


### PR DESCRIPTION
Adds support for in-app messaging to RN.

Adds event firing from native side into RN code, including (experimental) push calls as well. This will allow integrations with our SDK to work with push notifications directly, without needing to depend on and integrate with a third-party RN push library.