### PR TITLE
Add options null check

### DIFF
--- a/android/src/main/java/com/reactnativesnapyrrnsdk/SnapyrRnSdkModule.java
+++ b/android/src/main/java/com/reactnativesnapyrrnsdk/SnapyrRnSdkModule.java
@@ -67,7 +67,7 @@ public class SnapyrRnSdkModule extends ReactContextBaseJavaModule implements Lif
               }
             ));
 
-        if (options.hasKey("snapyrEnvironment")) {
+        if (options != null && options.hasKey("snapyrEnvironment")) {
           try {
             ConnectionFactory.Environment env = ConnectionFactory.Environment.values()[options.getInt("snapyrEnvironment")];
             builder.snapyrEnvironment(env);


### PR DESCRIPTION
The `options` argument is marked as optional in the types yet its properties are accessed without a null check natively causing configure to fail. Assuming this was just missed as the docs also show that only a key is required to use configure. 