### PR TITLE
iOS push callbacks

### DIFF
--- a/android/src/main/java/com/reactnativesnapyrrnsdk/SnapyrRnReceiverBase.java
+++ b/android/src/main/java/com/reactnativesnapyrrnsdk/SnapyrRnReceiverBase.java
@@ -37,7 +37,10 @@ public abstract class SnapyrRnReceiverBase extends BroadcastReceiver {
                                 }
                             });
                     // Init the React context - this allows JS code to run, so the emitted events can be received on the JS side. NB if starting from non-running app state, only app-level JS code will run - i.e. typically `index.js` code will run but not `App.jsx`, which is run within an Activity
-                    reactInstanceManager.createReactContextInBackground();
+
+                    // NB: disabling this for now as it's not yet being used, and can cause unexpected behavior in some apps.
+                    // TODO: make configurable, then re-enable based on config
+                    // reactInstanceManager.createReactContextInBackground();
                 } else {
                     // React context is ready - send the event immediately
                     reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)

--- a/android/src/main/java/com/reactnativesnapyrrnsdk/SnapyrRnSdkModule.java
+++ b/android/src/main/java/com/reactnativesnapyrrnsdk/SnapyrRnSdkModule.java
@@ -55,9 +55,6 @@ public class SnapyrRnSdkModule extends ReactContextBaseJavaModule implements Lif
     public void configure(String withKey, ReadableMap options, Promise promise) {
       try {
         Snapyr.Builder builder = new Snapyr.Builder(this.getCurrentContext(), withKey)
-        .flushQueueSize(1) // makes every event flush to network immediately
-        .trackApplicationLifecycleEvents() // Enable this to record certain application events automatically
-        .recordScreenViews() // Enable this to record screen views automatically
         .enableSnapyrPushHandling() // enable push for Android
         .configureInAppHandling(
           new InAppConfig()
@@ -65,12 +62,32 @@ public class SnapyrRnSdkModule extends ReactContextBaseJavaModule implements Lif
               SnapyrRnInAppHandler.getInstance(this.getReactApplicationContext())
             ));
 
-        if (options != null && options.hasKey("snapyrEnvironment")) {
-          try {
-            ConnectionFactory.Environment env = ConnectionFactory.Environment.values()[options.getInt("snapyrEnvironment")];
-            builder.snapyrEnvironment(env);
-          } catch (Exception e) {
-            Log.e("Snapyr", "Invalid environment provided");
+        if (options != null) {
+          if (options.hasKey("trackApplicationLifecycleEvents") && options.getBoolean("trackApplicationLifecycleEvents")) {
+            builder.trackApplicationLifecycleEvents(); // Enable this to record certain application events automatically
+          }
+
+          if (options.hasKey("recordScreenViews") && options.getBoolean("recordScreenViews")) {
+            builder.recordScreenViews(); // Enable this to record screen views automatically
+          }
+
+          if (options.hasKey("debug") && options.getBoolean("debug")) {
+            builder.logLevel(Snapyr.LogLevel.INFO);
+          }
+
+          if (options.hasKey("flushQueueSize")) {
+            builder.flushQueueSize(options.getInt("flushQueueSize"));
+          } else {
+            builder.flushQueueSize(1); // default - makes every event flush to network immediately
+          }
+
+          if (options.hasKey("snapyrEnvironment")) {
+            try {
+              ConnectionFactory.Environment env = ConnectionFactory.Environment.values()[options.getInt("snapyrEnvironment")];
+              builder.snapyrEnvironment(env);
+            } catch (Exception e) {
+              Log.e("Snapyr", "Invalid environment provided");
+            }
           }
         }
 

--- a/ios/SnapyrRnNotifManager.h
+++ b/ios/SnapyrRnNotifManager.h
@@ -1,0 +1,15 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Simple queue structure to dedupe notifications by ID. Keeps track of the last N notification IDs that were checked. Checking `shouldNotifyForId`returns false if the ID is already on the list; otherwise adds it to the list and returns true.
+ * If the queue reaches the max size, the first (oldest) ID is popped to make room for the new (latest) ID.
+ * There are multiple AppDelegate calls that may process the same notification, so this ensures any duplicate triggers on the same notification only result in one callback being triggered over in JS code.
+ */
+@interface SnapyrRnNotifManager : NSObject
+- (instancetype)initWithSize:(int)size;
+- (BOOL)shouldNotifyForId:(NSString *)notificationId;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/SnapyrRnNotifManager.m
+++ b/ios/SnapyrRnNotifManager.m
@@ -1,0 +1,34 @@
+#import "SnapyrRnNotifManager.h"
+
+@interface SnapyrRnNotifManager ()
+@property (nonatomic, assign) int listSize;
+@property (nonatomic, strong) NSMutableArray<NSString *> *list;
+@end
+
+@implementation SnapyrRnNotifManager
+
+- (instancetype)initWithSize:(int)size
+{
+    if (self = [self init]) {
+        _listSize = size;
+        _list = [NSMutableArray arrayWithCapacity:size];
+    }
+    return self;
+}
+
+- (BOOL)shouldNotifyForId:(NSString *)notificationId
+{
+    @synchronized (self) {
+        if ([_list containsObject:notificationId]) {
+            return NO;
+        }
+        if ([_list count] >= _listSize) {
+            // pop oldest entry off the top
+            [_list removeObjectAtIndex:0];
+        }
+        [_list addObject:notificationId];
+        return YES;
+    }
+}
+
+@end

--- a/ios/SnapyrRnSdk.m
+++ b/ios/SnapyrRnSdk.m
@@ -43,6 +43,9 @@ RCT_REMAP_METHOD(configure,
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 {
+    if ([_options objectForKey:@"debug"]) {
+        [SnapyrSDK debug:true];
+    }
     SnapyrSDKConfiguration *configuration = [SnapyrSDKConfiguration configurationWithWriteKey:key];
     if ([_options objectForKey:@"trackApplicationLifecycleEvents"]) {
         configuration.trackApplicationLifecycleEvents = YES; // Enable this to record certain application events automatically
@@ -50,16 +53,21 @@ RCT_REMAP_METHOD(configure,
     if ([_options objectForKey:@"recordScreenViews"]) {
         configuration.recordScreenViews = YES; // Enable this to record screen views automatically
     }
-    if ([_options objectForKey:@"snapyrEnvironment"]) {
+    if ([_options objectForKey:@"snapyrEnvironment"] != nil) {
         NSNumber *e = [_options valueForKey:@"snapyrEnvironment"];
         // NB this relies on integer-based enums with the same values between React and iOS
         configuration.snapyrEnvironment = (SnapyrEnvironment)e.integerValue; // Test against a Snapyr dev environment *internal only*
     }
+    if ([_options objectForKey:@"flushQueueSize"] != nil) {
+        NSNumber *e = [_options valueForKey:@"flushQueueSize"];
+        configuration.flushAt = [e intValue]; // Enable this to record screen views automatically
+    } else {
+        // default - makes every event flush to network immediately
+        configuration.flushAt = 1;
+    }
     configuration.actionHandler = ^(SnapyrInAppMessage *message){
         [self handleSnapyrInAppMessage:message];
     };
-    // makes every event flush to network immediately
-    configuration.flushAt = 1;
     
     [SnapyrSDK setupWithConfiguration:configuration];
     // Adding first listener kicks off `startObserving` so we're wired into events/notifications, even if JS code hasn't yet requested anything

--- a/ios/SnapyrRnSdk.m
+++ b/ios/SnapyrRnSdk.m
@@ -160,16 +160,14 @@ RCT_EXPORT_METHOD(requestPushAuthorization:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-//    [center auth]
     
     // NB: `requestAuthorizationWithOptions...` prompts user for permission and is needed to display alerts/badges/sounds, BUT...
     // `registerForRemoteNotifications` is what actually triggers APNs registration and the `didRegisterForRemoteNotificationsWithDeviceToken` callback.
     // `registerForRemoteNotifications` can be called BEFORE requesting authorization to get a push token (but only silent push will work until you get authorization).
-    // might want to do this early in swizzling to get device token, then allow client code to request authorization later?
     [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error) {
         if(!error) {
             // This triggers the AppDelegate's `didRegisterForRemoteNotificationsWithDeviceToken:` method if successful.
-            // NB up to AppDelegate to actually implement this method and pass back to Snapyr!
+            // NB up to client's AppDelegate to actually implement this method and pass back to Snapyr!
             dispatch_async(dispatch_get_main_queue(), ^{
                 [[UIApplication sharedApplication] registerForRemoteNotifications];
             });

--- a/ios/SnapyrRnSdk.m
+++ b/ios/SnapyrRnSdk.m
@@ -67,7 +67,7 @@ RCT_REMAP_METHOD(configure,
     }
     if ([_options objectForKey:@"flushQueueSize"] != nil) {
         NSNumber *e = [_options valueForKey:@"flushQueueSize"];
-        configuration.flushAt = [e intValue]; // Enable this to record screen views automatically
+        configuration.flushAt = [e intValue];
     } else {
         // default - makes every event flush to network immediately
         configuration.flushAt = 1;

--- a/ios/SnapyrRnSdk.m
+++ b/ios/SnapyrRnSdk.m
@@ -1,10 +1,39 @@
 #import "SnapyrRnSdk.h"
 #import <Snapyr/SnapyrSDK.h>
 #import <Snapyr/SnapyrInAppMessage.h>
+#import <Snapyr/SnapyrNotification.h>
+
+static SnapyrNotification *__receivedNotification = nil;
+static SnapyrNotification *__responseNotification = nil;
 
 @implementation SnapyrRnSdk
 
-RCT_EXPORT_MODULE()
+RCT_EXPORT_MODULE_NO_LOAD(SnapyrRnSdk, SnapyrRnSdk)
+
++ (void)load
+{
+    // + load is executed very early on in app lifecycle (at startup, before main app instance is even launched).
+    // Listen to notifications from Snapyr SDK that may be triggered before the RN SDK (or even the RN app itself) is initialized.
+    // We will stash the last received and responded notification record so that we can "replay" them after RN initialization.
+    // This allows for an app launch, triggered by a notification receipt or tap, to pass this data to the RN app
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(didReceiveRemoteNotification:)
+     name:@"snapyr.didReceiveNotification"
+     object:nil];
+    
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(didReceiveNotificationResponse:)
+     name:@"snapyr.didReceiveNotificationResponse"
+     object:nil];
+    
+    [[NSNotificationCenter defaultCenter]
+     addObserver:self
+     selector:@selector(registeredForRemoteNotificationsWithDeviceToken:)
+     name:@"snapyr.registeredForRemoteNotificationsWithDeviceToken"
+     object:nil];
+}
 
 // See https://reactnative.dev/docs/native-modules-ios
 
@@ -33,8 +62,11 @@ RCT_REMAP_METHOD(configure,
     configuration.flushAt = 1;
     
     [SnapyrSDK setupWithConfiguration:configuration];
-    
+    // Adding first listener kicks off `startObserving` so we're wired into events/notifications, even if JS code hasn't yet requested anything
     [self addListener:@"snapyrDidRegister"];
+    
+    // Check for updated push token - if AppDelegate has the requisite code wired up, this will result in the current push token being sent to Snapyr for the currently-identified user
+    [self requestPushTokenIfAuthorized];
     
     resolve(key);
 }
@@ -93,6 +125,47 @@ RCT_EXPORT_METHOD(reset)
     // Do nothing, for now... stub method to maintain compat w/ Android
 }
 
+RCT_EXPORT_METHOD(checkPushAuthorization:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
+{
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *settings){
+        
+        if (settings.authorizationStatus == UNAuthorizationStatusAuthorized) {
+            resolve(@"authorized");
+        } else if (settings.authorizationStatus == UNAuthorizationStatusDenied) {
+            resolve(@"denied");
+        } else {
+            resolve(@"undetermined");
+        }
+    }];
+}
+
+RCT_EXPORT_METHOD(requestPushAuthorization:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+//    [center auth]
+    
+    // NB: `requestAuthorizationWithOptions...` prompts user for permission and is needed to display alerts/badges/sounds, BUT...
+    // `registerForRemoteNotifications` is what actually triggers APNs registration and the `didRegisterForRemoteNotificationsWithDeviceToken` callback.
+    // `registerForRemoteNotifications` can be called BEFORE requesting authorization to get a push token (but only silent push will work until you get authorization).
+    // might want to do this early in swizzling to get device token, then allow client code to request authorization later?
+    [center requestAuthorizationWithOptions:(UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionBadge) completionHandler:^(BOOL granted, NSError * _Nullable error) {
+        if(!error) {
+            // This triggers the AppDelegate's `didRegisterForRemoteNotificationsWithDeviceToken:` method if successful.
+            // NB up to AppDelegate to actually implement this method and pass back to Snapyr!
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[UIApplication sharedApplication] registerForRemoteNotifications];
+            });
+            resolve([NSNumber numberWithBool:granted]);
+        } else {
+            NSLog(@"Push registration FAILED");
+            reject(@"error", @"Encountered error during authorization attempt", error);
+        }
+    }];
+}
+
 
 /**
  Native iOS -> React Native events (trigger RN callbacks from native)
@@ -119,29 +192,36 @@ RCT_EXPORT_METHOD(reset)
 // to manage lifecycle. Those class methods use NSNotificationCenter to pass the data along through
 // events; we listen to those events here in the actual instance, where we can then pass data back
 // into React Native.
--(void)startObserving {
+- (void)startObserving {
     // Set up any upstream listeners or background tasks as necessary
     [[NSNotificationCenter defaultCenter]
      addObserver:self
      selector:@selector(handleSnapyrDidRegister:)
-     name:@"snapyrDidRegister"
+     name:@"snapyrRN.didRegister"
      object:nil];
     
     [[NSNotificationCenter defaultCenter]
      addObserver:self
      selector:@selector(handleSnapyrDidReceiveNotification:)
-     name:@"snapyrDidReceiveNotification"
+     name:@"snapyrRN.didReceiveNotification"
      object:nil];
     
     [[NSNotificationCenter defaultCenter]
      addObserver:self
      selector:@selector(handleSnapyrDidReceiveNotificationResponse:)
-     name:@"snapyrDidReceiveNotificationResponse"
+     name:@"snapyrRN.didReceiveNotificationResponse"
      object:nil];
+    
+    if (__receivedNotification) {
+        [self sendEventWithName:@"snapyrDidReceiveNotification" body:[__receivedNotification asDict]];
+    }
+    if (__responseNotification) {
+        [self sendEventWithName:@"snapyrDidReceiveNotificationResponse" body:[__responseNotification asDict]];
+    }
 }
 
 // Will be called when this module's last listener is removed, or on dealloc.
--(void)stopObserving {
+- (void)stopObserving {
     // Remove upstream listeners, stop unnecessary background tasks
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
@@ -160,20 +240,30 @@ RCT_EXPORT_METHOD(reset)
 
 - (void)handleSnapyrDidReceiveNotification:(NSNotification *)notification
 {
-    NSDictionary *notif = notification.userInfo[@"notification"];
-    [self sendEventWithName:@"snapyrDidReceiveNotification" body:notif];
+    SnapyrNotification *snapyrNotification = notification.userInfo[@"snapyrNotification"];
+    [self sendEventWithName:@"snapyrDidReceiveNotification" body:[snapyrNotification asDict]];
 }
 
 - (void)handleSnapyrDidReceiveNotificationResponse:(NSNotification *)notification
 {
-    [self sendEventWithName:@"snapyrDidReceiveNotificationResponse" body:notification.userInfo];
+    SnapyrNotification *snapyrNotification = notification.userInfo[@"snapyrNotification"];
+    [self sendEventWithName:@"snapyrDidReceiveNotificationResponse" body:[snapyrNotification asDict]];
 }
 
-
-- (void)handleTest:(NSNotification *)notification
+// Helper - fire a `registerForRemoteNotifications` call IFF the app already has notification authorization
+- (void)requestPushTokenIfAuthorized
 {
-    NSString *notif = notification.userInfo[@"notification"];
-    [self sendEventWithName:@"snapyrTest" body:notif];
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+    [center getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *settings){
+        // Only try to get push token if user gave authorization (otherwise, we might "successfully" register the device with Snapyr as having a push token, with a token that can only be used for silent/background notifications
+        if (settings.authorizationStatus == UNAuthorizationStatusAuthorized) {
+            // This triggers the AppDelegate's `didRegisterForRemoteNotificationsWithDeviceToken:` method if successful.
+            // NB up to AppDelegate to actually implement this method and pass back to Snapyr!
+            dispatch_async(dispatch_get_main_queue(), ^{
+                [[UIApplication sharedApplication] registerForRemoteNotifications];
+            });
+        }
+  }];
 }
 
 // Class method the consumer can call when application(_:didRegisterForRemoteNotificationsWithDeviceToken:)
@@ -194,28 +284,49 @@ RCT_EXPORT_METHOD(reset)
     }
     
     [[NSNotificationCenter defaultCenter]
-     postNotificationName:@"snapyrDidRegister"
+     postNotificationName:@"snapyrRN.didRegister"
      object:self
      userInfo:@{@"token" : [hexString copy]}];
 }
 
-+ (void)didReceiveRemoteNotification:(NSDictionary *)notification
+#pragma mark - static notification listeners/forwarders
+// These methods listen for notifications from the Snapyr iOS SDK, and forward them (by sending a new notification) along to instance methods in the Snapyr RN SDK
+
++ (void)didReceiveRemoteNotification:(NSNotification *)notification
 {
+    SnapyrNotification *snapyrNotif = notification.userInfo[@"snapyrNotification"];
+    // Record of this notification for later forwarding, if RN SDK is initialized after this notification
+    __receivedNotification = snapyrNotif;
+
     [[NSNotificationCenter defaultCenter]
-     postNotificationName:@"snapyrDidReceiveNotification"
+     postNotificationName:@"snapyrRN.didReceiveNotification"
      object:self
-     userInfo:@{@"notification": notification}];
+     userInfo:@{@"snapyrNotification": snapyrNotif}];
 }
 
-+ (void)didReceiveNotificationResponse:(UNNotificationResponse *)response
++ (void)didReceiveNotificationResponse:(NSNotification *)notification
 API_AVAILABLE(ios(10.0))
 {
-    NSString *actionIdentifier = response.actionIdentifier;
-    NSDictionary *userInfo = [response.notification.request.content.userInfo copy];
+    SnapyrNotification *snapyrNotif = notification.userInfo[@"snapyrNotification"];
+    // Record of this notification for later forwarding, if RN SDK is initialized after this notification
+    __responseNotification = snapyrNotif;
+    
+    NSString *actionIdentifier = notification.userInfo[@"actionIdentifier"];
+    
     [[NSNotificationCenter defaultCenter]
-     postNotificationName:@"snapyrDidReceiveNotificationResponse"
+     postNotificationName:@"snapyrRN.didReceiveNotificationResponse"
      object:self
-     userInfo:@{@"actionIdentifier": actionIdentifier, @"userInfo": userInfo}];
+     userInfo:@{@"actionIdentifier": actionIdentifier, @"snapyrNotification": snapyrNotif}];
+}
+
++ (void)registeredForRemoteNotificationsWithDeviceToken:(NSNotification *)notification
+{
+    NSString *tokenString = notification.userInfo[@"tokenString"];
+
+    [[NSNotificationCenter defaultCenter]
+     postNotificationName:@"snapyrRN.registeredForRemoteNotificationsWithDeviceToken"
+     object:self
+     userInfo:@{@"tokenString": tokenString}];
 }
 
 + (BOOL)requiresMainQueueSetup

--- a/ios/SnapyrRnSdk.m
+++ b/ios/SnapyrRnSdk.m
@@ -1,7 +1,11 @@
 #import "SnapyrRnSdk.h"
+#import "SnapyrRnNotifManager.h"
 #import <Snapyr/SnapyrSDK.h>
 #import <Snapyr/SnapyrInAppMessage.h>
 #import <Snapyr/SnapyrNotification.h>
+
+static SnapyrRnNotifManager *__receivedNotificationIds = nil;
+static SnapyrRnNotifManager *__respondedNotificationIds = nil;
 
 static SnapyrNotification *__receivedNotification = nil;
 static SnapyrNotification *__responseNotification = nil;
@@ -33,6 +37,9 @@ RCT_EXPORT_MODULE_NO_LOAD(SnapyrRnSdk, SnapyrRnSdk)
      selector:@selector(registeredForRemoteNotificationsWithDeviceToken:)
      name:@"snapyr.registeredForRemoteNotificationsWithDeviceToken"
      object:nil];
+    
+    __receivedNotificationIds = [[SnapyrRnNotifManager alloc] initWithSize:20];
+    __respondedNotificationIds = [[SnapyrRnNotifManager alloc] initWithSize:20];
 }
 
 // See https://reactnative.dev/docs/native-modules-ios
@@ -303,6 +310,9 @@ RCT_EXPORT_METHOD(requestPushAuthorization:(RCTPromiseResolveBlock)resolve
 + (void)didReceiveRemoteNotification:(NSNotification *)notification
 {
     SnapyrNotification *snapyrNotif = notification.userInfo[@"snapyrNotification"];
+    if (![__receivedNotificationIds shouldNotifyForId:@(snapyrNotif.notificationId).stringValue]) {
+        return;
+    }
     // Record of this notification for later forwarding, if RN SDK is initialized after this notification
     __receivedNotification = snapyrNotif;
 
@@ -316,6 +326,9 @@ RCT_EXPORT_METHOD(requestPushAuthorization:(RCTPromiseResolveBlock)resolve
 API_AVAILABLE(ios(10.0))
 {
     SnapyrNotification *snapyrNotif = notification.userInfo[@"snapyrNotification"];
+    if (![__respondedNotificationIds shouldNotifyForId:@(snapyrNotif.notificationId).stringValue]) {
+        return;
+    }
     // Record of this notification for later forwarding, if RN SDK is initialized after this notification
     __responseNotification = snapyrNotif;
     

--- a/ios/SnapyrRnSdk.xcodeproj/project.pbxproj
+++ b/ios/SnapyrRnSdk.xcodeproj/project.pbxproj
@@ -7,9 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-
-		5E555C0D2413F4C50049A1A2 /* SnapyrRnSdk.m in Sources */ = {isa = PBXBuildFile; fileRef = B3E7B5891CC2AC0600A0062D /* SnapyrRnSdk.m */; };
-
+		DABDCE05294A7431007548D1 /* SnapyrRnNotifManager.m in Sources */ = {isa = PBXBuildFile; fileRef = DABDCE04294A7431007548D1 /* SnapyrRnNotifManager.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -26,10 +24,10 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libSnapyrRnSdk.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libSnapyrRnSdk.a; sourceTree = BUILT_PRODUCTS_DIR; };
-
 		B3E7B5881CC2AC0600A0062D /* SnapyrRnSdk.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrRnSdk.h; sourceTree = "<group>"; };
 		B3E7B5891CC2AC0600A0062D /* SnapyrRnSdk.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SnapyrRnSdk.m; sourceTree = "<group>"; };
-
+		DABDCE03294A7431007548D1 /* SnapyrRnNotifManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SnapyrRnNotifManager.h; sourceTree = "<group>"; };
+		DABDCE04294A7431007548D1 /* SnapyrRnNotifManager.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SnapyrRnNotifManager.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,10 +52,10 @@
 		58B511D21A9E6C8500147676 = {
 			isa = PBXGroup;
 			children = (
-
+				DABDCE03294A7431007548D1 /* SnapyrRnNotifManager.h */,
+				DABDCE04294A7431007548D1 /* SnapyrRnNotifManager.m */,
 				B3E7B5881CC2AC0600A0062D /* SnapyrRnSdk.h */,
 				B3E7B5891CC2AC0600A0062D /* SnapyrRnSdk.m */,
-
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -119,9 +117,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-
-				B3E7B58A1CC2AC0600A0062D /* SnapyrRnSdk.m in Sources */,
-
+				DABDCE05294A7431007548D1 /* SnapyrRnNotifManager.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -234,7 +230,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SnapyrRnSdk;
 				SKIP_INSTALL = YES;
-
 			};
 			name = Debug;
 		};
@@ -251,7 +246,6 @@
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = SnapyrRnSdk;
 				SKIP_INSTALL = YES;
-
 			};
 			name = Release;
 		};

--- a/react-native-snapyr-rn-sdk.podspec
+++ b/react-native-snapyr-rn-sdk.podspec
@@ -16,5 +16,5 @@ Pod::Spec.new do |s|
   s.source_files = "ios/**/*.{h,m,mm}"
 
   s.dependency "React-Core"
-  s.dependency "Snapyr", '~> 1.1.1'
+  s.dependency "Snapyr", '~> 1.2.0-beta1'
 end

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,6 +28,12 @@ export enum SnapyrEnvironment {
   SnapyrEnvironmentDev,
 }
 
+export enum SnapyrIosPushAuthStatus {
+  authorized = "authorized",
+  denied = "denied",
+  undetermined = "undetermined",
+}
+
 export type SnapyrConfigOptions = {
   trackApplicationLifecycleEvents: boolean;
   recordScreenViews: boolean;
@@ -142,8 +148,6 @@ export const onSnapyrInAppMessage = setupEventListener<SnapyrInAppMessage>(
 );
 
 /**
- * **Beta** - not yet fully supported for iOS
- *
  * Registers a callback that will be called when Snapyr receives a notification response, i.e. a tap on a notification.
  *
  * Only one callback can be registered at a time. Calling this function for a second time will replace the first callback with the second one.
@@ -154,8 +158,6 @@ export const onSnapyrNotificationResponse =
   );
 
 /**
- * **Beta** - not yet fully supported for iOS
- *
  * Registers a callback that will be called when Snapyr receives a notification.
  *
  * Only one callback can be registered at a time. Calling this function for a second time will replace the first callback with the second one.
@@ -164,6 +166,24 @@ export const onSnapyrNotificationReceived =
   setupEventListener<SnapyrPushNotificationPayload>(
     SNAPYR_LISTENER_NOTIFICATION
   );
+
+/**
+ * iOS only - trigger OS prompt to request permission from the user to send push notifications. 
+ * The prompt will display only if the user has not already accepted or denied such a prompt in the past; 
+ * otherwise, this method will immediately return with the push authorization status.
+ * Snapyr push notifications will only work after the user has granted push authorization for this app.
+ */
+export function requestIosPushAuthorization(): Promise<boolean> {
+  // promise resolved with boolean for whether user allowed; or rejected if there was an error during authorization attempt
+  return SnapyrRnSdk.requestPushAuthorization();
+}
+
+/**
+ * iOS only - get the current push authorization status. Push notifications are authorized/enabled only if the result is `SnapyrIosPushAuthStatus.authorized`.
+ */
+export function checkIosPushAuthorization(): Promise<SnapyrIosPushAuthStatus> {
+  return SnapyrRnSdk.checkPushAuthorization();
+}
 
 export function configure(
   key: string,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -176,6 +176,11 @@ export const onSnapyrNotificationReceived =
  * Snapyr push notifications will only work after the user has granted push authorization for this app.
  */
 export function requestIosPushAuthorization(): Promise<boolean> {
+  if (Platform.OS !== 'ios') {
+    throw new Error(
+      "Function valid only for iOS. Try wrapping call in `if (Platform.OS === 'ios') {...}"
+    );
+  }
   // promise resolved with boolean for whether user allowed; or rejected if there was an error during authorization attempt
   return SnapyrRnSdk.requestPushAuthorization();
 }
@@ -184,6 +189,11 @@ export function requestIosPushAuthorization(): Promise<boolean> {
  * iOS only - get the current push authorization status. Push notifications are authorized/enabled only if the result is `SnapyrIosPushAuthStatus.authorized`.
  */
 export function checkIosPushAuthorization(): Promise<SnapyrIosPushAuthStatus> {
+  if (Platform.OS !== 'ios') {
+    throw new Error(
+      "Function valid only for iOS. Try wrapping call in `if (Platform.OS === 'ios') {...}"
+    );
+  }
   return SnapyrRnSdk.checkPushAuthorization();
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -37,6 +37,8 @@ export enum SnapyrIosPushAuthStatus {
 export type SnapyrConfigOptions = {
   trackApplicationLifecycleEvents: boolean;
   recordScreenViews: boolean;
+  flushQueueSize: number;
+  debug: boolean;
   snapyrEnvironment: SnapyrEnvironment;
 };
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -29,9 +29,9 @@ export enum SnapyrEnvironment {
 }
 
 export enum SnapyrIosPushAuthStatus {
-  authorized = "authorized",
-  denied = "denied",
-  undetermined = "undetermined",
+  authorized = 'authorized',
+  denied = 'denied',
+  undetermined = 'undetermined',
 }
 
 export type SnapyrConfigOptions = {
@@ -170,8 +170,8 @@ export const onSnapyrNotificationReceived =
   );
 
 /**
- * iOS only - trigger OS prompt to request permission from the user to send push notifications. 
- * The prompt will display only if the user has not already accepted or denied such a prompt in the past; 
+ * iOS only - trigger OS prompt to request permission from the user to send push notifications.
+ * The prompt will display only if the user has not already accepted or denied such a prompt in the past;
  * otherwise, this method will immediately return with the push authorization status.
  * Snapyr push notifications will only work after the user has granted push authorization for this app.
  */


### PR DESCRIPTION
Support push notification "received" and "response" (i.e. "tap") callbacks for iOS.

This listens to internal notifications fired by the Snapyr iOS SDK with data about push notifications, and forwards along to JS when ready.

Includes some early initialization code to listen for these internal notifications, even before client has initialized the Snapyr SDK. Similar to the existing JS mechanism for storing and "replaying" events that arrive before listeners are registered, this allows the RN SDK to capture events for push notification response that caused an app launch. These occur before the React Native context is ready, so we store-and-forward after initialization is done.

Also fills in a couple more SDK configs to pass along from RN to native context.

NB: push callbacks on iOS still depend on client implementing some code in their AppDelegate. These updates are structured to go through the main Snapyr iOS SDK, which forwards the requisite data along to the RN SDK internally. As such, the code to implement in the AppDelegate is the same as for a native iOS app implementing the Snapyr iOS SDK, as below:

```objc
- (void)application:(UIApplication *)app didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
{
  // After successful push registration, this code decodes the device token and registers it with Snapyr. This is required to allow Snapyr campaigns to send push notifications to the device.
  [SnapyrSDK appRegisteredForRemoteNotificationsWithDeviceToken:deviceToken];
}

- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
  // This tells Snapyr that a notification successfully arrived on the device, and is required to allow your Snapyr campaigns to track the "received" rate for campaigns.
  [SnapyrSDK appDidReceiveRemoteNotification:userInfo];
  completionHandler(UIBackgroundFetchResultNewData);
}

- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
{
  // This tells Snapyr that a notification was tapped, and is required to allow your Snapyr campaigns to track the "clicked" rate for campaigns.
  // Snapyr will also attempt to open the deep link URL from the notification, if one was set on the push creative.
  [SnapyrSDK appDidReceiveNotificationResponse:response];
  // Do not remove the following line!
  completionHandler();
}

- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
{
  // This method is triggered if a notification is received while the app is in the foreground.
  // This tells Snapyr that a notification successfully arrived on the device, and is required to allow your Snapyr campaigns to track the "received" rate for campaigns.
  [SnapyrSDK appDidReceiveRemoteNotification:notification.request.content.userInfo];
  // Optional: by default, notifications received in the foreground are not displayed. If you would like to display the notification over the app, run the following line.
  completionHandler(UNNotificationPresentationOptionAlert);
}
```